### PR TITLE
Add emerge snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,6 +512,21 @@ jobs:
             bundle exec fastlane android verify_debug_view_snapshot_tests
       - android/save-build-cache
 
+  emerge_purchases_ui_snapshot_tests:
+    description: "Emerge purchases ui snapshot tests"
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/restore-build-cache
+      - run:
+          name: Build and run purchases ui snapshot tests
+          command: |
+            bundle exec fastlane android emerge_purchases_ui_snapshot_tests
+      - android/save-build-cache
+
   run-firebase-tests:
     description: "Run integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     alias libs.plugins.kover apply false
     alias libs.plugins.detekt
     alias libs.plugins.dependencyGraph
+    alias libs.plugins.emerge apply false
 //    Removing from here gives an error
 //    The request for this plugin could not be satisfied because the plugin is already on the classpath with an
 //    unknown version, so compatibility cannot be checked.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,11 @@ platform :android do
     gradle(task: "ui:debugview:recordPaparazziDebug")
   end
 
+  desc "Emerge snapshot tests"
+  lane :emerge_purchases_ui_snapshot_tests do
+    gradle(task: ":test-apps:testpurchasesuiandroidcompatibility:emergeUploadSnapshotBundleDebug")
+  end
+
   desc "Replaces version numbers, updates changelog and creates PR"
   lane :bump do |options|
     bump_version_update_changelog_create_pr(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,14 @@ Verify snapshot tests for the debug view library
 
 Record/Update snapshots for tests in the debug view library
 
+### android emerge_purchases_ui_snapshot_tests
+
+```sh
+[bundle exec] fastlane android emerge_purchases_ui_snapshot_tests
+```
+
+Run snapshot tests for the purchases UI library
+
 ### android bump
 
 ```sh

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,8 @@ commonmark = "0.21.0"
 activity-compose = "1.7.2"
 fragment = "1.6.1"
 hamcrest = "1.3"
+emergeGradlePlugin = "3.1.2"
+emergeSnapshots = "1.1.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -47,6 +49,7 @@ androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", ver
 dependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencyGraph" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id ="org.jetbrains.dokka", version.ref = "dokka"}
+emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -92,6 +95,8 @@ billing = { module = "com.android.billingclient:billing" , version.ref = "billin
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
+emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
+
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON"}
 
@@ -114,7 +119,7 @@ tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 kotlin-bom = "org.jetbrains.kotlin:kotlin-bom:1.8.0"
-compose-bom = "androidx.compose:compose-bom:2023.05.01"
+compose-bom = "androidx.compose:compose-bom:2024.06.00"
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util" }
 compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -50,7 +50,20 @@ android {
 }
 
 emerge {
+    // TODO: RevenueCat to set from CircleCi variables
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+
+    vcs {
+        // TODO: RevenueCat to set from CircleCi variables
+        sha.set("")
+        // TODO: RevenueCat to set from CircleCi variables
+        // Should skip setting for main branch uploads
+        baseSha.set("")
+        gitHub {
+            repoName.set("purchases-android")
+            repoOwner.set("RevenueCat")
+        }
+    }
 }
 
 dependencies {

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.emerge)
 }
 
 android {
@@ -48,9 +49,15 @@ android {
     }
 }
 
+emerge {
+    apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+}
+
 dependencies {
     implementation(project(":purchases"))
     implementation(project(":ui:revenuecatui"))
+
+    androidTestImplementation(libs.emerge.snapshots)
 
     implementation(platform(libs.kotlin.bom))
     implementation(libs.androidx.core)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Adds Emerge snapshots to purchases UI, as RevenueCat has expressed interest and we figured we'd make the process easier 😄 .

### Description
Integrates Emerge snapshots, involving a few things:
- Adds Emerge Gradle plugin
- Invokes snapshot task (`emergeUploadSnapshotBundleDebug`) from `testpurchasesuiandroidcompatibility` module
- Attempts to add the CircleCI/Fastlane setup to invoke as part of the CI step, where this will fit in the best.